### PR TITLE
Transition to Drawer Navigation from Tabs

### DIFF
--- a/app.json
+++ b/app.json
@@ -4,7 +4,7 @@
     "description": "Easily organize and collaborate on shopping lists with your family.",
     "slug": "pantryplus",
     "owner": "askewsoft",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "platforms": [
       "ios"
     ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@aws-amplify/ui-react-native": "^2.2.16",
         "@react-native-async-storage/async-storage": "1.23.1",
         "@react-native-community/netinfo": "11.3.1",
-        "@react-navigation/bottom-tabs": "6.5.11",
+        "@react-navigation/drawer": "^6.7.2",
         "@react-navigation/native": "6.1.9",
         "@react-navigation/stack": "6.3.20",
         "aws-amplify": "^6.6.7",
@@ -8759,24 +8759,6 @@
       "integrity": "sha512-pcE4i0X7y3hsAE0SpIl7t6dUc0B0NZLd1yv7ssm4FrLhWG+CGyIq4eFDXpmPU1XHmL5PPySxTAjEMiwv6tAmOw==",
       "license": "MIT"
     },
-    "node_modules/@react-navigation/bottom-tabs": {
-      "version": "6.5.11",
-      "resolved": "https://registry.npmjs.org/@react-navigation/bottom-tabs/-/bottom-tabs-6.5.11.tgz",
-      "integrity": "sha512-CBN/NOdxnMvmjw+AJQI1kltOYaClTZmGec5pQ3ZNTPX86ytbIOylDIITKMfTgHZcIEFQDymx1SHeS++PIL3Szw==",
-      "license": "MIT",
-      "dependencies": {
-        "@react-navigation/elements": "^1.3.21",
-        "color": "^4.2.3",
-        "warn-once": "^0.1.0"
-      },
-      "peerDependencies": {
-        "@react-navigation/native": "^6.0.0",
-        "react": "*",
-        "react-native": "*",
-        "react-native-safe-area-context": ">= 3.0.0",
-        "react-native-screens": ">= 3.0.0"
-      }
-    },
     "node_modules/@react-navigation/core": {
       "version": "6.4.17",
       "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-6.4.17.tgz",
@@ -8792,6 +8774,26 @@
       },
       "peerDependencies": {
         "react": "*"
+      }
+    },
+    "node_modules/@react-navigation/drawer": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@react-navigation/drawer/-/drawer-6.7.2.tgz",
+      "integrity": "sha512-o4g2zgTZa2+oLd+8V33etrSM38KIqu8S/zCBTsdsHUoQyVE7JNRiv3Qgq/jMvEb8PZCqWmm7jHItcgzrBuwyOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-navigation/elements": "^1.3.31",
+        "color": "^4.2.3",
+        "warn-once": "^0.1.0"
+      },
+      "peerDependencies": {
+        "@react-navigation/native": "^6.0.0",
+        "react": "*",
+        "react-native": "*",
+        "react-native-gesture-handler": ">= 1.0.0",
+        "react-native-reanimated": ">= 1.0.0",
+        "react-native-safe-area-context": ">= 3.0.0",
+        "react-native-screens": ">= 3.0.0"
       }
     },
     "node_modules/@react-navigation/elements": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@aws-amplify/ui-react-native": "^2.2.16",
     "@react-native-async-storage/async-storage": "1.23.1",
     "@react-native-community/netinfo": "11.3.1",
-    "@react-navigation/bottom-tabs": "6.5.11",
+    "@react-navigation/drawer": "^6.7.2",
     "@react-navigation/native": "6.1.9",
     "@react-navigation/stack": "6.3.20",
     "aws-amplify": "^6.6.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pantryplus",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "scripts": {
     "start": "npx expo start --dev-client",
     "prebuild": "NODE_NO_WARNINGS=1 npx expo prebuild",

--- a/src/components/BottomActionBar.tsx
+++ b/src/components/BottomActionBar.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+
+import colors from '@/consts/colors';
+
+type BottomActionBarProps = {
+  children: React.ReactNode;
+};
+
+const BottomActionBar = ({ children }: BottomActionBarProps) => {
+  return (
+    <View style={styles.container}>
+      {children}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-around',
+    backgroundColor: colors.brandColor,
+    paddingVertical: 8,
+    paddingHorizontal: 16,
+    height: 50,
+    borderTopWidth: 0,
+    marginTop: -1,
+  },
+});
+
+export default BottomActionBar;

--- a/src/components/Buttons/BottomActionButton.tsx
+++ b/src/components/Buttons/BottomActionButton.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { TouchableOpacity, Text, StyleSheet } from 'react-native';
+import MaterialIcons from '@expo/vector-icons/MaterialIcons';
+
+import colors from '@/consts/colors';
+import fonts from '@/consts/fonts';
+
+type BottomActionButtonProps = {
+  label: string;
+  iconName: React.ComponentProps<typeof MaterialIcons>['name'];
+  onPress: () => void;
+  disabled?: boolean;
+};
+
+const BottomActionButton = ({
+  label,
+  iconName,
+  onPress,
+  disabled = false,
+}: BottomActionButtonProps) => {
+  return (
+    <TouchableOpacity
+      style={[
+        styles.button,
+        disabled && styles.buttonDisabled
+      ]}
+      onPress={onPress}
+      disabled={disabled}
+      activeOpacity={0.7}
+      accessibilityLabel={label}
+      accessibilityHint={`Tap to ${label.toLowerCase()}`}
+      accessibilityRole="button"
+    >
+      <MaterialIcons
+        name={iconName}
+        size={24}
+        color={disabled ? colors.inactiveButtonColor : colors.white}
+      />
+      <Text style={[
+        styles.buttonText,
+        disabled && styles.buttonTextDisabled
+      ]}>
+        {label}
+      </Text>
+    </TouchableOpacity>
+  );
+};
+
+const styles = StyleSheet.create({
+  button: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.brandColor,
+    paddingVertical: 12,
+    paddingHorizontal: 20,
+    borderRadius: 8,
+    marginHorizontal: 8,
+    minHeight: 48,
+  },
+  buttonDisabled: {
+    backgroundColor: colors.inactiveButtonColor,
+  },
+  buttonText: {
+    color: colors.white,
+    fontSize: fonts.messageTextSize,
+    fontWeight: 'bold',
+    marginLeft: 8,
+  },
+  buttonTextDisabled: {
+    color: colors.inactiveButtonColor,
+  },
+});
+
+export default BottomActionButton;

--- a/src/components/Buttons/HamburgerButton.tsx
+++ b/src/components/Buttons/HamburgerButton.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { TouchableOpacity, StyleSheet } from 'react-native';
+import MaterialIcons from '@expo/vector-icons/MaterialIcons';
+
+import colors from '@/consts/colors';
+import { iconSize } from '@/consts/iconButtons';
+
+type HamburgerButtonProps = {
+  onPress: () => void;
+};
+
+const HamburgerButton = ({ onPress }: HamburgerButtonProps) => {
+  return (
+    <TouchableOpacity
+      style={styles.button}
+      onPress={onPress}
+      activeOpacity={0.7}
+      accessibilityLabel="Menu"
+      accessibilityHint="Opens navigation menu"
+      accessibilityRole="button"
+    >
+      <MaterialIcons
+        name="menu"
+        size={iconSize.rowIconSize}
+        color={colors.white}
+      />
+    </TouchableOpacity>
+  );
+};
+
+const styles = StyleSheet.create({
+  button: {
+    padding: 8,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});
+
+export default HamburgerButton;

--- a/src/components/CategoryFolder.tsx
+++ b/src/components/CategoryFolder.tsx
@@ -1,7 +1,6 @@
 import { useState, useRef } from 'react';
 import { View, Text, StyleSheet, Pressable, TextInput } from 'react-native';
 import { observer } from 'mobx-react-lite';
-import { ScaleDecorator } from 'react-native-draggable-flatlist';
 import AntDesign from '@expo/vector-icons/AntDesign';
 
 import colors from '@/consts/colors';
@@ -26,8 +25,7 @@ const CategoryFolder = ({categoryId, title, children}: {categoryId: string, titl
 
   // Calculate unpurchased items count for this category
   // Since purchased items are removed from the category, all items are unpurchased
-  const unpurchasedItemsCount = currCategory ? 
-    currCategory.items.length : 0;
+  const unpurchasedItemsCount = currCategory ? currCategory.items.length : 0;
 
   const onSubmit = async () => {
     if (editedTitle.trim().toLowerCase() !== currCategory?.name.trim().toLowerCase()) {
@@ -52,53 +50,49 @@ const CategoryFolder = ({categoryId, title, children}: {categoryId: string, titl
   }
 
   return (
-    <ScaleDecorator activeScale={1.04}>
-      <View ref={categoryRef} style={styles.container}>
-          {uiStore.showCategoryLabels && (
-            <Pressable
-              onPress={toggleFolderOpenClose}
-            >
-              <View style={styles.titleContainer}>
-                <AntDesign
-                  name={open ? "folderopen" : "folder1"}
-                  size={iconSize.rowIconSize}
-                  backgroundColor={colors.lightBrandColor}
-                  color={colors.white}
-                  iconStyle={{ padding: 0, margin: 0 }}
+    <View ref={categoryRef} style={styles.container}>
+      {uiStore.showCategoryLabels && (
+        <Pressable onPress={toggleFolderOpenClose}>
+          <View style={styles.titleContainer}>
+            <AntDesign
+              name={open ? "folderopen" : "folder1"}
+              size={iconSize.rowIconSize}
+              backgroundColor={colors.lightBrandColor}
+              color={colors.white}
+              iconStyle={{ padding: 0, margin: 0 }}
+            />
+            <View style={styles.titleAndBadgeContainer}>
+              {isEditing ? (
+                <TextInput
+                  style={[styles.title, styles.titleInput]}
+                  value={editedTitle}
+                  onSubmitEditing={onSubmit}
+                  onChangeText={(text) => setEditedTitle(text)}
+                  autoFocus={true}
+                  inputMode="text"
+                  lineBreakStrategyIOS="none"
+                  clearButtonMode="while-editing"
+                  enablesReturnKeyAutomatically={true}
+                  keyboardAppearance="light"
+                  returnKeyType="done"
+                  blurOnSubmit={true}
                 />
-                <View style={styles.titleAndBadgeContainer}>
-                  {isEditing ? (
-                    <TextInput
-                      style={[styles.title, styles.titleInput]}
-                      value={editedTitle}
-                      onSubmitEditing={onSubmit}
-                      onChangeText={(text) => setEditedTitle(text)}
-                      autoFocus={true}
-                      inputMode="text"
-                      lineBreakStrategyIOS="none"
-                      clearButtonMode="while-editing"
-                      enablesReturnKeyAutomatically={true}
-                      keyboardAppearance="light"
-                      returnKeyType="done"
-                      blurOnSubmit={true}
-                    />
-                  ) : (
-                    <Text style={styles.title}>{title}</Text>
-                  )}
-                  <Badge count={unpurchasedItemsCount} size="small" />
-                </View>
-                <View style={styles.buttonContainer}>
-                  <CategoryContextMenu
-                    onRename={onRenameCategory}
-                    onDelete={onDeleteCategory}
-                  />
-                </View>
-              </View>
-            </Pressable>
-          )}
-          {children}
-        </View>
-    </ScaleDecorator>
+              ) : (
+                <Text style={styles.title}>{title}</Text>
+              )}
+              <Badge count={unpurchasedItemsCount} size="small" />
+            </View>
+            <View style={styles.buttonContainer}>
+              <CategoryContextMenu
+                onRename={onRenameCategory}
+                onDelete={onDeleteCategory}
+              />
+            </View>
+          </View>
+        </Pressable>
+      )}
+      {children}
+    </View>
   );
 };
 

--- a/src/components/CategoryItems.tsx
+++ b/src/components/CategoryItems.tsx
@@ -24,9 +24,9 @@ const CategoryItems = ({ listId, categoryId }: { listId: string, categoryId: str
       easing: Easing.cubic,
       useNativeDriver: false,
     });
-    
+
     animation.start();
-    
+
     return () => {
       animation.stop();
     };
@@ -40,7 +40,7 @@ const CategoryItems = ({ listId, categoryId }: { listId: string, categoryId: str
       }),
       opacity: heightAnim,
       overflow: 'hidden',
-      marginTop: uiStore.showCategoryLabels ? 5 : 0,
+      marginTop: uiStore.showCategoryLabels ? 1 : 0,
     }}>
       <ItemsList
         items={currCategory?.items ?? []}

--- a/src/components/ContextMenus/ListContextMenu.tsx
+++ b/src/components/ContextMenus/ListContextMenu.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { View, TouchableOpacity, StyleSheet, NativeSyntheticEvent } from 'react-native';
+import { observer } from 'mobx-react-lite';
+import ContextMenu, { ContextMenuOnPressNativeEvent } from 'react-native-context-menu-view';
+import MaterialIcons from '@expo/vector-icons/MaterialIcons';
+
+import colors from '@/consts/colors';
+import { iconSize } from '@/consts/iconButtons';
+
+type ListContextMenuProps = {
+  onShare: () => void;
+  onRename: () => void;
+  onDelete: () => void;
+  userIsListOwner: boolean;
+};
+
+const ListContextMenu = observer(({
+  onShare,
+  onRename,
+  onDelete,
+  userIsListOwner,
+}: ListContextMenuProps) => {
+  const actionConfigs = [
+    {
+      title: 'Share List',
+      systemIcon: 'square.and.arrow.up',
+      handler: onShare,
+      visible: userIsListOwner,
+    },
+    {
+      title: 'Rename List',
+      systemIcon: 'pencil',
+      handler: onRename,
+      visible: userIsListOwner,
+    },
+    {
+      title: 'Delete List',
+      systemIcon: 'trash',
+      destructive: true,
+      handler: onDelete,
+      visible: userIsListOwner,
+    },
+  ].filter(action => action.visible);
+
+  const handleActionPress = (e: NativeSyntheticEvent<ContextMenuOnPressNativeEvent>) => {
+    const { index } = e.nativeEvent;
+    const actionConfig = actionConfigs[index];
+    if (actionConfig?.handler) {
+      actionConfig.handler();
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <ContextMenu
+        actions={actionConfigs.map(({ title, systemIcon, destructive }) => ({ title, systemIcon, destructive }))}
+        onPress={handleActionPress}
+        dropdownMenuMode={true}
+        previewBackgroundColor={colors.itemBackground}
+      >
+        <TouchableOpacity
+          style={styles.menuButton}
+          activeOpacity={0.7}
+          accessibilityLabel="List Menu"
+          accessibilityHint="Opens menu with options to share, rename, or delete list"
+          accessibilityRole="button"
+        >
+          <MaterialIcons
+            name="more-horiz"
+            size={iconSize.rowIconSize}
+            color={colors.brandColor}
+          />
+        </TouchableOpacity>
+      </ContextMenu>
+    </View>
+  );
+});
+
+const styles = StyleSheet.create({
+  container: {
+    marginRight: 8,
+  },
+  menuButton: {
+    padding: 8,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});
+
+export default ListContextMenu;

--- a/src/components/ContextMenus/ShoppingListContextMenu.tsx
+++ b/src/components/ContextMenus/ShoppingListContextMenu.tsx
@@ -11,8 +11,6 @@ import colors from '@/consts/colors';
 import { iconSize } from '@/consts/iconButtons';
 
 type ShoppingListContextMenuProps = {
-  onAddCategory: () => void;
-  onAddItem: () => void;
   onToggleEmptyFolders: () => void;
   onToggleAllFolders: () => void;
   onReorderCategories: () => void;
@@ -20,8 +18,6 @@ type ShoppingListContextMenuProps = {
 };
 
 const ShoppingListContextMenu = observer(({
-  onAddCategory,
-  onAddItem,
   onToggleEmptyFolders,
   onToggleAllFolders,
   onReorderCategories,
@@ -32,17 +28,8 @@ const ShoppingListContextMenu = observer(({
   const unpurchasedItemsCount = currentList?.unpurchasedItemsCount ?? 0;
 
   // Single source of truth for actions and their handlers
+  // Note: Add Item and Add Category have been moved to the bottom action bar
   const actionConfigs = [
-    {
-      title: 'Add Item',
-      systemIcon: 'plus.circle',
-      handler: onAddItem,
-    },
-    {
-      title: 'Add Category',
-      systemIcon: 'folder.badge.plus',
-      handler: onAddCategory,
-    },
     {
       title: 'Reorder Categories',
       systemIcon: 'arrow.up.arrow.down',
@@ -120,4 +107,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default ShoppingListContextMenu; 
+export default ShoppingListContextMenu;

--- a/src/components/ItemsList.tsx
+++ b/src/components/ItemsList.tsx
@@ -15,14 +15,14 @@ type ItemsListProps = {
   indent?: number;
 };
 
-const ItemsList = observer(({ 
-  items, 
+const ItemsList = observer(({
+  items,
   listId,
   categoryId,
   indent = 10,
 }: ItemsListProps) => {
   return (
-    <View style={[styles.draggableFlatListStyle, { paddingTop: uiStore.showCategoryLabels ? 5 : 0 }]}>
+    <View style={[styles.draggableFlatListStyle, { paddingTop: uiStore.showCategoryLabels ? 1 : 0 }]}>
       {toJS(items).map((item: ItemType) => (
         <Item
           key={item.id}
@@ -42,4 +42,4 @@ const styles = StyleSheet.create({
   }
 });
 
-export default ItemsList; 
+export default ItemsList;

--- a/src/screens/GroupsNavigation/MyGroups.tsx
+++ b/src/screens/GroupsNavigation/MyGroups.tsx
@@ -1,9 +1,12 @@
-import { Text, StyleSheet, Pressable, RefreshControl } from 'react-native';
+import { Text, StyleSheet, Pressable, RefreshControl, View } from 'react-native';
 import { toJS } from 'mobx';
 import { observer } from 'mobx-react-lite';
 import { useEffect } from 'react';
 import { NestableScrollContainer, NestableDraggableFlatList } from "react-native-draggable-flatlist";
 import { MaterialIcons } from '@expo/vector-icons';
+
+import BottomActionBar from '@/components/BottomActionBar';
+import BottomActionButton from '@/components/Buttons/BottomActionButton';
 
 import { domainStore, GroupType } from '@/stores/DomainStore';
 import { uiStore } from '@/stores/UIStore';
@@ -34,6 +37,11 @@ const MyGroups = ({navigation}: StackPropsMyGroups) => {
     navigation.navigate('MyInvites');
   }
 
+  const onPressAddGroup = () => {
+    uiStore.setGroupCreationOrigin('Groups');
+    uiStore.setAddGroupModalVisible(true);
+  };
+
   const renderGroupElement = ({ item }: { item: GroupType }) => {
     const group = domainStore.groups.find(g => g.id === item.id);
     const userIsGroupOwner = group?.owner.email === domainStore.user?.email;
@@ -62,20 +70,40 @@ const MyGroups = ({navigation}: StackPropsMyGroups) => {
 
   return (
     <ErrorBoundary>
-      <NestableScrollContainer refreshControl={<RefreshControl refreshing={!uiStore.groupsLoaded} onRefresh={onRefresh} />}>
-        {numInvites > 0 && <InviteNotice />}
-        <NestableDraggableFlatList
-          data={toJS(domainStore.groups)}
-          renderItem={renderGroupElement}
-          keyExtractor={group => group.id}
-        />
-        <AddGroupModal navigation={navigation} />
-      </NestableScrollContainer>
+      <View style={styles.container}>
+        <NestableScrollContainer style={styles.scrollContainer} refreshControl={<RefreshControl refreshing={!uiStore.groupsLoaded} onRefresh={onRefresh} />}>
+          {numInvites > 0 && <InviteNotice />}
+          <NestableDraggableFlatList
+            style={styles.draggableList}
+            data={toJS(domainStore.groups)}
+            renderItem={renderGroupElement}
+            keyExtractor={group => group.id}
+          />
+        </NestableScrollContainer>
+        <BottomActionBar>
+          <BottomActionButton
+            label="Add Group"
+            iconName="add-circle"
+            onPress={onPressAddGroup}
+          />
+        </BottomActionBar>
+      </View>
+      <AddGroupModal navigation={navigation} />
     </ErrorBoundary>
   );
 }
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    height: '100%',
+  },
+  scrollContainer: {
+    flex: 1,
+  },
+  draggableList: {
+    height: '80%',
+  },
   inviteBadge: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/src/screens/GroupsNavigation/index.tsx
+++ b/src/screens/GroupsNavigation/index.tsx
@@ -1,45 +1,26 @@
 import { useEffect, useRef } from 'react';
 import { observer } from 'mobx-react-lite';
-import { View, StyleSheet } from 'react-native';
 import { createStackNavigator } from '@react-navigation/stack';
-import { EventArg, StackNavigationState } from '@react-navigation/native';
 
 import { GroupsStack, GroupsStackParamList } from '@/types/GroupNavTypes';
 import stackNavScreenOptions from '@/consts/stackNavOptions';
 
 import MyGroups from './MyGroups';
 import MyInvites from './MyInvites';
-import AddButton from '@/components/Buttons/AddButton';
+import HamburgerButton from '@/components/Buttons/HamburgerButton';
 
-import colors from '@/consts/colors';
 import { uiStore } from '@/stores/UIStore';
 import { domainStore } from '@/stores/DomainStore';
 
-const onPressAddGroup = () => {
-  // Track that user is creating a group from the Groups screen directly
-  uiStore.setGroupCreationOrigin('Groups');
-  uiStore.setAddGroupModalVisible(true);
-};
-
 const { Navigator, Screen } = createStackNavigator<GroupsStackParamList>();
-
-const renderHeader = () => {
-  return (
-    <View style={styles.headerContainer}>
-      <AddButton
-        label="Add Group"
-        onPress={onPressAddGroup}
-        foreground={colors.white}
-        background={colors.brandColor}
-        materialIconName="add-circle"
-      />
-    </View>
-  );
-}
 
 const GroupsNavigation = ({navigation}: {navigation: any}) => {
   // Add a ref to track the previous route so we can detect when the user navigates to a non-default screen explicitly
   const prevRoute = useRef<string | null>(null);
+
+  const onOpenDrawer = () => {
+    navigation.openDrawer();
+  };
 
   useEffect(() => {
     if (uiStore.lastViewedSection === 'Groups' && GroupsStack.includes(uiStore.lastViewedSubSection as typeof GroupsStack[number])) {
@@ -78,7 +59,7 @@ const GroupsNavigation = ({navigation}: {navigation: any}) => {
         options={{
           title: 'My Groups',
           headerMode: 'float',
-          headerRight: renderHeader,
+          headerRight: () => <HamburgerButton onPress={onOpenDrawer} />,
         }}
       />
       <Screen
@@ -91,16 +72,5 @@ const GroupsNavigation = ({navigation}: {navigation: any}) => {
     </Navigator>
   );
 }
-
-const styles = StyleSheet.create({
-  headerContainer: {
-    flex: 1,
-    flexDirection: 'row',
-    justifyContent: 'flex-end',
-    alignItems: 'center',
-    margin: 0,
-    padding: 0,
-  }
-});
 
 export default observer(GroupsNavigation);

--- a/src/screens/GroupsNavigation/index.tsx
+++ b/src/screens/GroupsNavigation/index.tsx
@@ -59,7 +59,7 @@ const GroupsNavigation = ({navigation}: {navigation: any}) => {
         options={{
           title: 'My Groups',
           headerMode: 'float',
-          headerRight: () => <HamburgerButton onPress={onOpenDrawer} />,
+          headerLeft: () => <HamburgerButton onPress={onOpenDrawer} />,
         }}
       />
       <Screen

--- a/src/screens/GroupsNavigation/modals/AddGroupModal.tsx
+++ b/src/screens/GroupsNavigation/modals/AddGroupModal.tsx
@@ -21,7 +21,7 @@ const AddGroupModal = ({ navigation }: { navigation: any }) => {
 
   const handleGroupCreation = async (newGroupId: string) => {
     uiStore.setAddGroupModalVisible(false);
-    
+
     // Handle navigation based on origin
     if (uiStore.groupCreationOrigin === 'Lists') {
       // Navigate back to Lists if user came from there
@@ -30,10 +30,10 @@ const AddGroupModal = ({ navigation }: { navigation: any }) => {
       // Stay on Groups screen if user navigated directly there
       // The new group will be visible in the list
     }
-    
+
     // Clear the origin tracking
     uiStore.clearGroupCreationOrigin();
-    
+
     // Handle sharing if needed
     optionallyShareShoppingList(newGroupId);
   };
@@ -46,7 +46,7 @@ const AddGroupModal = ({ navigation }: { navigation: any }) => {
   const onCancel = () => {
     uiStore.setAddGroupModalVisible(false);
     uiStore.clearGroupCreationOrigin();
-    
+
     if (uiStore.selectedShoppingList) {
       uiStore.setShareModalVisible(true);
       navigation.goBack();
@@ -93,8 +93,7 @@ const styles = StyleSheet.create({
     justifyContent: 'flex-start',
     alignItems: 'center',
     backgroundColor: colors.brandColor,
-    paddingVertical: 50,
-    marginTop: '60%',
+    marginTop: '50%',
   },
   modalTitle: {
     fontSize: fonts.modalTitleSize,
@@ -114,4 +113,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default observer(AddGroupModal);  
+export default observer(AddGroupModal);

--- a/src/screens/ListsNavigation/MyLists.tsx
+++ b/src/screens/ListsNavigation/MyLists.tsx
@@ -3,6 +3,9 @@ import { StyleSheet, View, Text, Button, RefreshControl } from 'react-native';
 import { toJS } from 'mobx';
 import DraggableFlatList from 'react-native-draggable-flatlist';
 
+import BottomActionBar from '@/components/BottomActionBar';
+import BottomActionButton from '@/components/Buttons/BottomActionButton';
+
 import { StackPropsListsMyLists } from '@/types/ListNavTypes';
 import ListElement from '@/components/ListElement';
 import AddListModal from './modals/AddListModal';
@@ -39,36 +42,58 @@ const MyLists = ({navigation}: StackPropsListsMyLists) => {
   if (domainStore.lists.length <= 0 && !uiStore.addListModalVisible) {
     return (
       <ErrorBoundary>
-        <View style={styles.noListsContainer}>
-          <Text style={styles.noListsText}>No lists yet.</Text>
-          <Button title="Click here to create a list" onPress={onPressAddList} color={colors.brandColor} />
+        <View style={styles.container}>
+          <View style={styles.noListsContainer}>
+            <Text style={styles.noListsText}>No lists yet.</Text>
+            <Button title="Click here to create a list" onPress={onPressAddList} color={colors.brandColor} />
+          </View>
+          <BottomActionBar>
+            <BottomActionButton
+              label="Add List"
+              iconName="add-circle"
+              onPress={onPressAddList}
+            />
+          </BottomActionBar>
         </View>
       </ErrorBoundary>
     );
   } else {
     return (
-      /* IFF DraggableFlatList creates problems,
-      * investigate https://github.com/fivecar/react-native-draglist
-      */
       <ErrorBoundary>
-        <DraggableFlatList
-          style={styles.draggableFlatListStyle}
-          data={toJS(domainStore.lists).sort(sortByOrdinal)}
-          onDragEnd={domainStore.updateListOrder}
-          renderItem={renderListElement(navigation)}
-          keyExtractor={list => list.id}
-          refreshControl={<RefreshControl refreshing={!uiStore.listsLoaded} onRefresh={onRefresh} />}
-        />
+        <View style={styles.container}>
+          <DraggableFlatList
+            style={styles.draggableFlatListStyle}
+            contentContainerStyle={styles.listContentContainer}
+            data={toJS(domainStore.lists).sort(sortByOrdinal)}
+            onDragEnd={domainStore.updateListOrder}
+            renderItem={renderListElement(navigation)}
+            keyExtractor={list => list.id}
+            refreshControl={<RefreshControl refreshing={!uiStore.listsLoaded} onRefresh={onRefresh} />}
+          />
+          <BottomActionBar>
+            <BottomActionButton
+              label="Add List"
+              iconName="add-circle"
+              onPress={onPressAddList}
+            />
+          </BottomActionBar>
+        </View>
         <AddListModal />
         <ShareListModal navigation={navigation} />
-    </ErrorBoundary>
+      </ErrorBoundary>
     );
   }
 }
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
   draggableFlatListStyle: {
-    height: '100%',
+    height: '93.5%',
+  },
+  listContentContainer: {
+    paddingBottom: 0,
   },
   noListsContainer: {
     flex: 1,

--- a/src/screens/ListsNavigation/MyLists.tsx
+++ b/src/screens/ListsNavigation/MyLists.tsx
@@ -1,7 +1,6 @@
 import { observer } from 'mobx-react-lite';
-import { StyleSheet, View, Text, Button, RefreshControl } from 'react-native';
+import { StyleSheet, View, Text, Button, RefreshControl, FlatList } from 'react-native';
 import { toJS } from 'mobx';
-import DraggableFlatList from 'react-native-draggable-flatlist';
 
 import BottomActionBar from '@/components/BottomActionBar';
 import BottomActionButton from '@/components/Buttons/BottomActionButton';
@@ -10,10 +9,10 @@ import { StackPropsListsMyLists } from '@/types/ListNavTypes';
 import ListElement from '@/components/ListElement';
 import AddListModal from './modals/AddListModal';
 import ShareListModal from './modals/ShareListModal';
+import ReorderListsModal from './modals/ReorderListsModal';
 import ErrorBoundary from '@/components/ErrorBoundary';
 
 import { domainStore, ListType } from '@/stores/DomainStore';
-import { FnReturnVoid } from '@/types/FunctionArgumentTypes';
 
 import colors from '@/consts/colors';
 import fonts from '@/consts/fonts';
@@ -21,9 +20,9 @@ import { uiStore } from '@/stores/UIStore';
 import { sortByOrdinal } from '@/stores/utils/sorter';
 
 const renderListElement = (navigation: any) => {
-  return ({ item, drag }: { item: ListType, drag: FnReturnVoid }) => {
+  return ({ item }: { item: ListType }) => {
     return (
-      <ListElement id={item.id} drag={drag} navigation={navigation}/>
+      <ListElement id={item.id} navigation={navigation}/>
     );
   }
 }
@@ -31,6 +30,10 @@ const renderListElement = (navigation: any) => {
 const MyLists = ({navigation}: StackPropsListsMyLists) => {
   const onPressAddList = () => {
     uiStore.setAddListModalVisible(true);
+  };
+
+  const onPressReorderLists = () => {
+    uiStore.setReorderListsModalVisible(true);
   };
 
   const onRefresh = async () => {
@@ -61,16 +64,20 @@ const MyLists = ({navigation}: StackPropsListsMyLists) => {
     return (
       <ErrorBoundary>
         <View style={styles.container}>
-          <DraggableFlatList
-            style={styles.draggableFlatListStyle}
+          <FlatList
+            style={styles.flatListStyle}
             contentContainerStyle={styles.listContentContainer}
             data={toJS(domainStore.lists).sort(sortByOrdinal)}
-            onDragEnd={domainStore.updateListOrder}
             renderItem={renderListElement(navigation)}
             keyExtractor={list => list.id}
             refreshControl={<RefreshControl refreshing={!uiStore.listsLoaded} onRefresh={onRefresh} />}
           />
           <BottomActionBar>
+            <BottomActionButton
+              label="Reorder"
+              iconName="reorder"
+              onPress={onPressReorderLists}
+            />
             <BottomActionButton
               label="Add List"
               iconName="add-circle"
@@ -80,6 +87,7 @@ const MyLists = ({navigation}: StackPropsListsMyLists) => {
         </View>
         <AddListModal />
         <ShareListModal navigation={navigation} />
+        <ReorderListsModal />
       </ErrorBoundary>
     );
   }
@@ -89,7 +97,7 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
   },
-  draggableFlatListStyle: {
+  flatListStyle: {
     height: '93.5%',
   },
   listContentContainer: {

--- a/src/screens/ListsNavigation/ShoppingList.tsx
+++ b/src/screens/ListsNavigation/ShoppingList.tsx
@@ -113,30 +113,22 @@ const ShoppingList = observer(({ navigation }: { navigation: any }) => {
 
   return (
     <ErrorBoundary>
-      <View style={styles.container}>
-        <View style={styles.contentWrapper}>
-          <CurrentLocation onPress={setCurrentLocation} />
-          <ScrollView
+            <View style={styles.container}>
+        <CurrentLocation onPress={setCurrentLocation} />
+        {/* Only render content if we have a valid list */}
+        {currentList && (
+          <FlatList
             ref={scrollViewRef}
-            style={styles.scrollContainer}
+            style={styles.flatListStyle}
+            data={toJS(currentList.categories)
+              .filter(category => uiStore.showEmptyFolders || category.items.length > 0)
+              .sort(sortByOrdinal)}
+            renderItem={renderCategoryElement}
+            keyExtractor={category => category.id}
+            ListHeaderComponent={<ListItems listId={listId!} />}
             refreshControl={<RefreshControl refreshing={isRefreshing} onRefresh={loadData} />}
-          >
-            {/* Only render content if we have a valid list */}
-            {currentList && (
-              <View style={styles.contentContainer}>
-                <ListItems listId={listId!} />
-                <FlatList
-                  style={styles.flatListStyle}
-                  data={toJS(currentList.categories)
-                    .filter(category => uiStore.showEmptyFolders || category.items.length > 0)
-                    .sort(sortByOrdinal)}
-                  renderItem={renderCategoryElement}
-                  keyExtractor={category => category.id}
-                />
-              </View>
-            )}
-          </ScrollView>
-        </View>
+          />
+        )}
         <BottomActionBar>
           <BottomActionButton
             label="Add Item"
@@ -163,18 +155,8 @@ const styles = StyleSheet.create({
     flex: 1,
     flexDirection: 'column',
   },
-  contentWrapper: {
-    flex: 1,
-    flexDirection: 'column',
-  },
-  scrollContainer: {
-    flex: 1,
-    flexDirection: 'column',
-  },
-  contentContainer: {
-    paddingBottom: 20, // padding for content above bottom action bar
-  },
   flatListStyle: {
+    flex: 1,
     backgroundColor: colors.detailsBackground,
   }
 });

--- a/src/screens/ListsNavigation/ShoppingList.tsx
+++ b/src/screens/ListsNavigation/ShoppingList.tsx
@@ -1,11 +1,8 @@
 import { useEffect, useState, useRef } from 'react';
-import { StyleSheet, RefreshControl, Alert, View } from 'react-native';
+import { StyleSheet, RefreshControl, Alert, View, FlatList, ScrollView } from 'react-native';
 import { toJS } from 'mobx';
 import { observer } from 'mobx-react-lite';
-import { DragEndParams } from 'react-native-draggable-flatlist';
-import { NestableScrollContainer, NestableDraggableFlatList } from "react-native-draggable-flatlist";
 
-import { FnReturnVoid } from '@/types/FunctionArgumentTypes';
 import CategoryFolder from '@/components/CategoryFolder';
 import CategoryItems from '@/components/CategoryItems';
 import ListItems from '@/components/ListItems';
@@ -15,6 +12,8 @@ import PickLocationPrompt from './modals/PickLocationPrompt';
 import ReorderCategoriesModal from './modals/ReorderCategoriesModal';
 import CurrentLocation from '@/components/CurrentLocation';
 import ErrorBoundary from '@/components/ErrorBoundary';
+import BottomActionBar from '@/components/BottomActionBar';
+import BottomActionButton from '@/components/Buttons/BottomActionButton';
 
 import { uiStore } from '@/stores/UIStore';
 import { domainStore } from '@/stores/DomainStore';
@@ -27,7 +26,7 @@ const ShoppingList = observer(({ navigation }: { navigation: any }) => {
   const xAuthUser = domainStore.user?.email;
   const [isRefreshing, setIsRefreshing] = useState(false);
   const scrollViewRef = useRef<any>(null);
-  
+
   // Get current list as a computed value and ensure it exists
   const currentList = domainStore.lists.find((list) => list.id === listId);
 
@@ -35,18 +34,18 @@ const ShoppingList = observer(({ navigation }: { navigation: any }) => {
     // Verify list still exists in store before loading
     const listStillExists = domainStore.lists.find((list) => list.id === listId);
     if (!listStillExists || !xAuthUser) return;
-    
+
     setIsRefreshing(true);
     try {
       // Create a reference to the current list's ID to verify it hasn't changed
       const loadingListId = listId;
-      
+
       // Verify list ID hasn't changed before each operation
       if (loadingListId === uiStore.selectedShoppingList) {
         const xAuthLocation = domainStore.selectedKnownLocationId ?? '';
         await listStillExists.loadCategories({ xAuthUser, xAuthLocation });
       }
-      
+
       if (loadingListId === uiStore.selectedShoppingList) {
         await listStillExists.loadListItems({ xAuthUser });
       }
@@ -61,63 +60,16 @@ const ShoppingList = observer(({ navigation }: { navigation: any }) => {
     }
   };
 
-  const renderCategoryElement = ({ item: category, drag }: { item: CategoryType, drag: FnReturnVoid }) => {
-    const xAuthLocation = domainStore.selectedKnownLocationId ?? '';
-    
-    // Only allow drag if location is set
-    const conditionalDrag = () => {
-      if (xAuthLocation === '') {
-        uiStore.setPickLocationPromptVisible(true);
-        return;
-      }
-      drag();
-    };
-
+  const renderCategoryElement = ({ item: category }: { item: CategoryType }) => {
     return (
-      <CategoryFolder 
-        key={category.id} 
-        categoryId={category.id} 
-        title={category.name} 
+      <CategoryFolder
+        key={category.id}
+        categoryId={category.id}
+        title={category.name}
       >
         <CategoryItems listId={listId!} categoryId={category.id} />
       </CategoryFolder>
     );
-  };
-
-  const onDragBegin = () => {
-    // This will only be called if drag is allowed (location is set)
-    // No need to check location here since we prevent drag from starting
-  }
-
-  const onDragEnd = ({ data }: DragEndParams<CategoryType>) => {
-    if (!currentList || !xAuthUser) return;
-
-    const xAuthLocation = domainStore.selectedKnownLocationId ?? '';
-    if (xAuthLocation === '') {
-      // Prompt the user to select a location, if there is no nearest known location already set
-      uiStore.setPickLocationPromptVisible(true);
-      return;
-    }
-
-    // Update the ordinals in sequence to avoid race conditions
-    const updateOrdinals = async () => {
-      try {
-        for (let i = 0; i < data.length; i++) {
-          const category = data[i];
-          if (category.ordinal !== i) {
-            const updatedCategory = currentList.categories.find(c => c.id === category.id);
-            if (updatedCategory) {
-              await updatedCategory.setOrdinal(i, xAuthUser, xAuthLocation);
-            }
-          }
-        }
-      } catch (error) {
-        console.error('Error updating category order:', error);
-        Alert.alert('Error', 'Failed to update category order. Please try again.');
-      }
-    };
-
-    updateOrdinals();
   };
 
   useEffect(() => {
@@ -129,7 +81,7 @@ const ShoppingList = observer(({ navigation }: { navigation: any }) => {
       // Get a fresh reference to the list
       const currentList = domainStore.lists.find((list) => list.id === listId);
       if (!currentList || !xAuthUser) return;
-      
+
       loadData();
       // Only update navigation title if list still exists
       if (currentList && currentList.name) {
@@ -151,52 +103,78 @@ const ShoppingList = observer(({ navigation }: { navigation: any }) => {
     navigation.navigate('Locations', { screen: 'MyLocations', params: { returnToList: true } });
   }
 
+  const onPressAddCategory = () => {
+    uiStore.setAddCategoryModalVisible(true);
+  };
+
+  const onPressAddItem = () => {
+    uiStore.setAddItemModalVisible(true);
+  };
+
   return (
     <ErrorBoundary>
       <View style={styles.container}>
-        <CurrentLocation onPress={setCurrentLocation} />
-        <NestableScrollContainer 
-          ref={scrollViewRef}
-          style={styles.scrollContainer} 
-          refreshControl={<RefreshControl refreshing={isRefreshing} onRefresh={loadData} />}
-        >
-          {/* Only render content if we have a valid list */}
-          {currentList && (
-            <View style={styles.contentContainer}>
-              <ListItems listId={listId!} />
-              <NestableDraggableFlatList
-                style={styles.draggableFlatListStyle}
-                data={toJS(currentList.categories)
-                  .filter(category => uiStore.showEmptyFolders || category.items.length > 0)
-                  .sort(sortByOrdinal)}
-                renderItem={renderCategoryElement}
-                keyExtractor={category => category.id}
-                onDragBegin={onDragBegin}
-                onDragEnd={onDragEnd}
-              />
-              <AddCategoryModal />
-              <AddItemModal />
-              <PickLocationPrompt onPress={setCurrentLocation} />
-              <ReorderCategoriesModal />
-            </View>
-          )}
-        </NestableScrollContainer>
+        <View style={styles.contentWrapper}>
+          <CurrentLocation onPress={setCurrentLocation} />
+          <ScrollView
+            ref={scrollViewRef}
+            style={styles.scrollContainer}
+            refreshControl={<RefreshControl refreshing={isRefreshing} onRefresh={loadData} />}
+          >
+            {/* Only render content if we have a valid list */}
+            {currentList && (
+              <View style={styles.contentContainer}>
+                <ListItems listId={listId!} />
+                <FlatList
+                  style={styles.flatListStyle}
+                  data={toJS(currentList.categories)
+                    .filter(category => uiStore.showEmptyFolders || category.items.length > 0)
+                    .sort(sortByOrdinal)}
+                  renderItem={renderCategoryElement}
+                  keyExtractor={category => category.id}
+                />
+              </View>
+            )}
+          </ScrollView>
+        </View>
+        <BottomActionBar>
+          <BottomActionButton
+            label="Add Item"
+            iconName="add-circle"
+            onPress={onPressAddItem}
+          />
+          <BottomActionButton
+            label="Add Category"
+            iconName="create-new-folder"
+            onPress={onPressAddCategory}
+          />
+        </BottomActionBar>
       </View>
+      <AddCategoryModal />
+      <AddItemModal />
+      <PickLocationPrompt onPress={setCurrentLocation} />
+      <ReorderCategoriesModal />
     </ErrorBoundary>
   );
 });
 
 const styles = StyleSheet.create({
   container: {
+    flex: 1,
+    flexDirection: 'column',
+  },
+  contentWrapper: {
+    flex: 1,
     flexDirection: 'column',
   },
   scrollContainer: {
+    flex: 1,
     flexDirection: 'column',
   },
   contentContainer: {
-    marginBottom: 18, // unsure why w/o this the tabNavBar covers the bottom of the list
+    paddingBottom: 20, // padding for content above bottom action bar
   },
-  draggableFlatListStyle: {
+  flatListStyle: {
     backgroundColor: colors.detailsBackground,
   }
 });

--- a/src/screens/ListsNavigation/index.tsx
+++ b/src/screens/ListsNavigation/index.tsx
@@ -83,7 +83,7 @@ const ListsNavigation = ({navigation}: {navigation: any}) => {
   const myListsOptions = {
     title: 'My Lists',
     headerMode: 'float' as const,
-    headerRight: () => <HamburgerButton onPress={onOpenDrawer} />
+    headerLeft: () => <HamburgerButton onPress={onOpenDrawer} />
   }
 
   const shoppingListOptions = {

--- a/src/screens/ListsNavigation/index.tsx
+++ b/src/screens/ListsNavigation/index.tsx
@@ -6,14 +6,13 @@ import { createStackNavigator } from '@react-navigation/stack';
 import MyLists from './MyLists';
 import ShoppingList from './ShoppingList';
 
-import AddButton from '@/components/Buttons/AddButton';
+import HamburgerButton from '@/components/Buttons/HamburgerButton';
 import ShoppingListContextMenu from '@/components/ContextMenus/ShoppingListContextMenu';
 import { uiStore } from '@/stores/UIStore';
 import { domainStore } from '@/stores/DomainStore';
 
 import { ListsStack, ListsStackParamList } from '@/types/ListNavTypes';
 import stackNavScreenOptions from '@/consts/stackNavOptions';
-import colors from '@/consts/colors';
 
 const { Navigator, Screen } = createStackNavigator<ListsStackParamList>();
 
@@ -41,10 +40,6 @@ const ListsNavigation = ({navigation}: {navigation: any}) => {
     prevRoute.current = currentRoute;
   }
 
-  const onPressAddList = () => {
-    uiStore.setAddListModalVisible(true);
-  };
-
   const onPressAddCategory = () => {
     uiStore.setAddCategoryModalVisible(true);
   };
@@ -52,6 +47,10 @@ const ListsNavigation = ({navigation}: {navigation: any}) => {
   const onPressAddProduct = () => {
     uiStore.setAddItemModalVisible(true);
   }
+
+  const onOpenDrawer = () => {
+    navigation.openDrawer();
+  };
 
   const ListHeaderRight = () => {
     return (
@@ -90,23 +89,11 @@ const ListsNavigation = ({navigation}: {navigation: any}) => {
       />
     );
   }
-
-
   
   const myListsOptions = {
     title: 'My Lists',
     headerMode: 'float' as const,
-    headerRight: () => {
-      return (
-        <AddButton
-          label="Add List"
-          foreground={colors.white}
-          background={colors.brandColor}
-          materialIconName="add-circle"
-          onPress={onPressAddList}
-        />
-      );
-    }
+    headerRight: () => <HamburgerButton onPress={onOpenDrawer} />
   }
 
   const shoppingListOptions = {

--- a/src/screens/ListsNavigation/index.tsx
+++ b/src/screens/ListsNavigation/index.tsx
@@ -40,14 +40,6 @@ const ListsNavigation = ({navigation}: {navigation: any}) => {
     prevRoute.current = currentRoute;
   }
 
-  const onPressAddCategory = () => {
-    uiStore.setAddCategoryModalVisible(true);
-  };
-
-  const onPressAddProduct = () => {
-    uiStore.setAddItemModalVisible(true);
-  }
-
   const onOpenDrawer = () => {
     navigation.openDrawer();
   };
@@ -55,8 +47,6 @@ const ListsNavigation = ({navigation}: {navigation: any}) => {
   const ListHeaderRight = () => {
     return (
       <ShoppingListContextMenu
-        onAddCategory={onPressAddCategory}
-        onAddItem={onPressAddProduct}
         onToggleEmptyFolders={() => {
           uiStore.setShowEmptyFolders(!uiStore.showEmptyFolders);
         }}
@@ -89,7 +79,7 @@ const ListsNavigation = ({navigation}: {navigation: any}) => {
       />
     );
   }
-  
+
   const myListsOptions = {
     title: 'My Lists',
     headerMode: 'float' as const,

--- a/src/screens/ListsNavigation/modals/AddCategoryModal.tsx
+++ b/src/screens/ListsNavigation/modals/AddCategoryModal.tsx
@@ -41,15 +41,15 @@ const AddCategoryModal = () => {
 }
 
 const onSubmit = async (evt: any) => {
-    const { selectedShoppingList: listId } = uiStore; 
+    const { selectedShoppingList: listId } = uiStore;
     const currList = domainStore.lists.find((list) => list.id === listId);
     const user = domainStore.user;
     const xAuthLocation = domainStore.selectedKnownLocationId ?? '';
-    currList?.addCategory({ 
-        name: evt.nativeEvent.text, 
-        xAuthUser: user?.email!, 
+    currList?.addCategory({
+        name: evt.nativeEvent.text,
+        xAuthUser: user?.email!,
         xAuthLocation,
-        defaultOpen: uiStore.allFoldersOpen 
+        defaultOpen: uiStore.allFoldersOpen
     });
     uiStore.setAddCategoryModalVisible(false);
 }
@@ -61,8 +61,7 @@ const styles = StyleSheet.create({
     justifyContent: 'flex-start',
     alignItems: 'center',
     backgroundColor: colors.brandColor,
-    paddingVertical: 50,
-    marginTop: '60%',
+    marginTop: '50%',
   },
   modalTitle: {
     fontSize: fonts.modalTitleSize,
@@ -82,4 +81,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default observer(AddCategoryModal);  
+export default observer(AddCategoryModal);

--- a/src/screens/ListsNavigation/modals/AddItemModal.tsx
+++ b/src/screens/ListsNavigation/modals/AddItemModal.tsx
@@ -15,7 +15,7 @@ const AddItemModal = () => {
 
   const listId = uiStore.selectedShoppingList;
   const currentList = domainStore.lists.find((list) => list.id === listId);
-  
+
   // Get category items directly from the DomainStore - always up to date
   const categoryItems = useMemo(() => {
     if (currentList) {
@@ -68,8 +68,8 @@ const AddItemModal = () => {
         if (selectedCategoryId && selectedCategoryId !== '') {
           // Add item to specific category
           const category = currentList.categories.find(c => c.id === selectedCategoryId);
-          category?.addItem({ 
-            item: { name: trimmedName, upc: '' }, 
+          category?.addItem({
+            item: { name: trimmedName, upc: '' },
             xAuthUser,
             onItemAdded: () => currentList.loadUnpurchasedItemsCount({ xAuthUser })
           });
@@ -78,7 +78,7 @@ const AddItemModal = () => {
           currentList.addItem({ item: { name: trimmedName, upc: '' }, xAuthUser });
         }
       }
-      
+
       // Clear the input for next item
       setItemName('');
       // Clear editing information
@@ -89,23 +89,23 @@ const AddItemModal = () => {
 
   const handleCategoryChange = () => {
     if (!currentList || !uiStore.editingItemName) return;
-    
+
     const user = domainStore.user;
     const xAuthUser = user?.email!;
     const originalCategoryId = uiStore.editingItemCategoryId;
     const newCategoryId = selectedCategoryId;
-    
+
     // Only proceed if category actually changed
     if (originalCategoryId === newCategoryId) return;
-    
-    // NOTE: When an Item is moved to a different category, that relationship needs to be 
-    // persisted to the database via the API. Currently, this implementation removes the item 
-    // from the original location and creates a new item in the new location, which results 
+
+    // NOTE: When an Item is moved to a different category, that relationship needs to be
+    // persisted to the database via the API. Currently, this implementation removes the item
+    // from the original location and creates a new item in the new location, which results
     // in API calls to createItem() and associateCategoryItem()/associateListItem().
-    // 
-    // Future consideration: Prevent duplicate Items by first looking for similarly named 
+    //
+    // Future consideration: Prevent duplicate Items by first looking for similarly named
     // Items when adding to a List, but this depends on how the data model unfolds in the database.
-    
+
     // Find the item in the original category or list
     let itemToMove = null;
     if (originalCategoryId) {
@@ -113,8 +113,8 @@ const AddItemModal = () => {
       itemToMove = originalCategory?.items.find(i => i.name === uiStore.editingItemName);
       if (itemToMove && originalCategory) {
         // Remove from original category
-        originalCategory.removeItem({ 
-          itemId: itemToMove.id, 
+        originalCategory.removeItem({
+          itemId: itemToMove.id,
           xAuthUser,
           onItemRemoved: () => currentList.loadUnpurchasedItemsCount({ xAuthUser })
         });
@@ -127,13 +127,13 @@ const AddItemModal = () => {
         currentList.removeItem({ itemId: itemToMove.id, xAuthUser });
       }
     }
-    
+
     // Add to new category or list
     if (itemToMove) {
       if (newCategoryId && newCategoryId !== '') {
         const newCategory = currentList.categories.find(c => c.id === newCategoryId);
-        newCategory?.addItem({ 
-          item: { name: uiStore.editingItemName!, upc: itemToMove.upc || '' }, 
+        newCategory?.addItem({
+          item: { name: uiStore.editingItemName!, upc: itemToMove.upc || '' },
           xAuthUser,
           onItemAdded: () => currentList.loadUnpurchasedItemsCount({ xAuthUser })
         });
@@ -148,7 +148,7 @@ const AddItemModal = () => {
     if (uiStore.editingItemName && uiStore.editingItemCategoryId !== selectedCategoryId) {
       handleCategoryChange();
     }
-    
+
     uiStore.setAddItemModalVisible(false);
     uiStore.setEditingItemName(null);
     uiStore.setEditingItemCategoryId(null);
@@ -169,7 +169,7 @@ const AddItemModal = () => {
       transparent={true}
       animationType="slide"
     >
-      <KeyboardAvoidingView 
+      <KeyboardAvoidingView
         behavior={Platform.OS === "ios" ? "padding" : "height"}
         style={styles.keyboardAvoidingView}
       >
@@ -177,7 +177,7 @@ const AddItemModal = () => {
           <Text style={styles.modalTitle}>
             {uiStore.editingItemName ? 'Edit Item' : 'Add Item'}
           </Text>
-          
+
           <View style={styles.dropdownContainer}>
             <DropDownPicker
               open={categoryOpen}
@@ -238,8 +238,7 @@ const styles = StyleSheet.create({
     justifyContent: 'flex-start',
     alignItems: 'center',
     backgroundColor: colors.brandColor,
-    paddingVertical: 20,
-    marginTop: '40%',
+    marginTop: '50%',
   },
   modalTitle: {
     fontSize: fonts.modalTitleSize,
@@ -282,4 +281,4 @@ const styles = StyleSheet.create({
   }
 });
 
-export default observer(AddItemModal); 
+export default observer(AddItemModal);

--- a/src/screens/ListsNavigation/modals/AddListModal.tsx
+++ b/src/screens/ListsNavigation/modals/AddListModal.tsx
@@ -56,9 +56,7 @@ const styles = StyleSheet.create({
     justifyContent: 'flex-start',
     alignItems: 'center',
     backgroundColor: colors.brandColor,
-    opacity: 0.9,
-    paddingVertical: 50,
-    marginTop: '60%',
+    marginTop: '50%',
   },
   modalTitle: {
     fontSize: fonts.modalTitleSize,
@@ -78,4 +76,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default observer(AddListModal);  
+export default observer(AddListModal);

--- a/src/screens/ListsNavigation/modals/ReorderListsModal.tsx
+++ b/src/screens/ListsNavigation/modals/ReorderListsModal.tsx
@@ -1,0 +1,201 @@
+import React from 'react';
+import { Modal, View, Text, StyleSheet, TouchableOpacity, Alert } from 'react-native';
+import { observer } from 'mobx-react-lite';
+import { toJS } from 'mobx';
+import { DragEndParams } from 'react-native-draggable-flatlist';
+import DraggableFlatList from 'react-native-draggable-flatlist';
+import MaterialIcons from '@expo/vector-icons/MaterialIcons';
+
+import { uiStore } from '@/stores/UIStore';
+import { domainStore, ListType } from '@/stores/DomainStore';
+import { FnReturnVoid } from '@/types/FunctionArgumentTypes';
+import colors from '@/consts/colors';
+import fonts from '@/consts/fonts';
+import { iconSize } from '@/consts/iconButtons';
+import { sortByOrdinal } from '@/stores/utils/sorter';
+
+const ReorderListsModal = () => {
+  const xAuthUser = domainStore.user?.email;
+
+  const onClose = () => {
+    uiStore.setReorderListsModalVisible(false);
+  };
+
+  const onSave = () => {
+    uiStore.setReorderListsModalVisible(false);
+  };
+
+  const renderListItem = ({ item: list, drag }: { item: ListType, drag: FnReturnVoid }) => {
+    return (
+      <TouchableOpacity
+        style={styles.listItem}
+        onLongPress={drag}
+        activeOpacity={0.7}
+      >
+        <MaterialIcons
+          name="drag-indicator"
+          size={iconSize.rowIconSize}
+          color={colors.lightBrandColor}
+          style={styles.dragIcon}
+        />
+        <Text style={styles.listName}>{list.name}</Text>
+      </TouchableOpacity>
+    );
+  };
+
+  const onDragEnd = ({ data }: DragEndParams<ListType>) => {
+    if (!xAuthUser) return;
+
+    // Update the ordinals in sequence to avoid race conditions
+    const updateOrdinals = async () => {
+      try {
+        for (let i = 0; i < data.length; i++) {
+          const list = data[i];
+          if (list.ordinal !== i) {
+            const updatedList = domainStore.lists.find(l => l.id === list.id);
+            if (updatedList) {
+              await updatedList.setOrdinal(i, xAuthUser);
+            }
+          }
+        }
+      } catch (error) {
+        console.error('Error updating list order:', error);
+        Alert.alert('Error', 'Failed to update list order. Please try again.');
+      }
+    };
+
+    updateOrdinals();
+  };
+
+  return (
+    <Modal
+      visible={uiStore.reorderListsModalVisible}
+      transparent={true}
+      animationType="slide"
+    >
+      <View style={styles.modalContainer}>
+        <View style={styles.modalContent}>
+          <View style={styles.header}>
+            <Text style={styles.title}>Reorder Lists</Text>
+            <TouchableOpacity onPress={onClose} style={styles.closeButton}>
+              <MaterialIcons name="close" size={24} color={colors.white} />
+            </TouchableOpacity>
+          </View>
+
+          <View style={styles.buttonContainer}>
+            <TouchableOpacity onPress={onClose} style={styles.cancelButton}>
+              <Text style={styles.cancelButtonText}>Cancel</Text>
+            </TouchableOpacity>
+            <TouchableOpacity onPress={onSave} style={styles.saveButton}>
+              <Text style={styles.saveButtonText}>Done</Text>
+            </TouchableOpacity>
+          </View>
+
+          <DraggableFlatList
+            data={toJS(domainStore.lists).sort(sortByOrdinal)}
+            renderItem={renderListItem}
+            keyExtractor={list => list.id}
+            onDragEnd={onDragEnd}
+            style={styles.list}
+            ListEmptyComponent={() => (
+              <Text style={styles.emptyText}>No lists found</Text>
+            )}
+          />
+        </View>
+      </View>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  modalContainer: {
+    flex: 1,
+    flexDirection: 'column',
+    justifyContent: 'flex-start',
+    alignItems: 'center',
+    backgroundColor: colors.brandColor,
+    paddingVertical: 20,
+    marginTop: '10%',
+  },
+  modalContent: {
+    flex: 1,
+    width: '90%',
+    flexDirection: 'column',
+    minHeight: 0,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 20,
+  },
+  title: {
+    fontSize: fonts.rowTextSize,
+    fontWeight: 'bold',
+    color: colors.white,
+  },
+  closeButton: {
+    padding: 4,
+  },
+  buttonContainer: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    gap: 8,
+    marginBottom: 20,
+  },
+  list: {
+    height: '80%',
+    backgroundColor: colors.brandColor,
+    borderRadius: 8,
+    padding: 8,
+  },
+  listItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: colors.detailsBackground,
+    padding: 12,
+    marginVertical: 2,
+    borderRadius: 6,
+  },
+  dragIcon: {
+    marginRight: 8,
+  },
+  listName: {
+    flex: 1,
+    fontSize: fonts.messageTextSize,
+    fontWeight: 'bold',
+    color: colors.brandColor,
+  },
+  cancelButton: {
+    flex: 1,
+    backgroundColor: colors.inactiveButtonColor,
+    padding: 12,
+    borderRadius: 6,
+    alignItems: 'center',
+  },
+  cancelButtonText: {
+    color: colors.white,
+    fontSize: fonts.messageTextSize,
+    fontWeight: 'bold',
+  },
+  saveButton: {
+    flex: 1,
+    backgroundColor: colors.lightBrandColor,
+    padding: 12,
+    borderRadius: 6,
+    alignItems: 'center',
+  },
+  saveButtonText: {
+    color: colors.white,
+    fontSize: fonts.messageTextSize,
+    fontWeight: 'bold',
+  },
+  emptyText: {
+    color: colors.white,
+    fontSize: fonts.rowTextSize,
+    textAlign: 'center',
+    marginTop: 20,
+  },
+});
+
+export default observer(ReorderListsModal);

--- a/src/screens/LocationsNavigation/MyLocations.tsx
+++ b/src/screens/LocationsNavigation/MyLocations.tsx
@@ -13,6 +13,8 @@ import colors from '@/consts/colors';
 
 import AddLocationModal from './modals/AddLocationModal';
 import LocationElement from '@/components/LocationElement';
+import BottomActionBar from '@/components/BottomActionBar';
+import BottomActionButton from '@/components/Buttons/BottomActionButton';
 
 const MyLocations = ({navigation, route}: {navigation: any, route: any}) => {
   const returnToList = route.params?.returnToList;
@@ -40,31 +42,53 @@ const MyLocations = ({navigation, route}: {navigation: any, route: any}) => {
     uiStore.setLocationsLoaded(true);
   }
 
+  const onPressAddLocation = () => {
+    uiStore.setAddLocationModalVisible(true);
+  };
+
   return (
     <ErrorBoundary>
       <View style={styles.container}>
-        {domainStore.nearestKnownLocation && (
-          <LocationElement id={domainStore.nearestKnownLocation.id} navigation={navigation} returnToList={returnToList}/>
-        )}
-        <Text style={styles.title}>Locations of past purchases</Text>
-        <DraggableFlatList
-          data={toJS(domainStore.locations)}
-          renderItem={renderLocationElement(navigation)}
-          keyExtractor={location => location.id}
-          refreshControl={<RefreshControl refreshing={!uiStore.locationsLoaded} onRefresh={onRefresh} />}
-        />
-        {domainStore.locations?.length === 0 && (
-          <Button title="Reload Locations" onPress={() => domainStore.loadRecentLocations()} />
-        )}
-        <AddLocationModal />
+        <View style={styles.contentContainer}>
+          {domainStore.nearestKnownLocation && (
+            <LocationElement id={domainStore.nearestKnownLocation.id} navigation={navigation} returnToList={returnToList}/>
+          )}
+          <Text style={styles.title}>Locations of past purchases</Text>
+          <DraggableFlatList
+            style={styles.draggableFlatListStyle}
+            data={toJS(domainStore.locations)}
+            renderItem={renderLocationElement(navigation)}
+            keyExtractor={location => location.id}
+            refreshControl={<RefreshControl refreshing={!uiStore.locationsLoaded} onRefresh={onRefresh} />}
+          />
+          {domainStore.locations?.length === 0 && (
+            <Button title="Reload Locations" onPress={() => domainStore.loadRecentLocations()} />
+          )}
+        </View>
+        <BottomActionBar>
+          <BottomActionButton
+            label="Add Location"
+            iconName="add-location"
+            onPress={onPressAddLocation}
+          />
+        </BottomActionBar>
       </View>
+      <AddLocationModal />
     </ErrorBoundary>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
+    flex: 1,
+    flexDirection: 'column',
+  },
+  contentContainer: {
+    flex: 1,
     alignItems: 'center',
+  },
+  draggableFlatListStyle: {
+    height: '93%',
   },
   title: {
     fontSize: fonts.infoTextSize,

--- a/src/screens/LocationsNavigation/index.tsx
+++ b/src/screens/LocationsNavigation/index.tsx
@@ -43,7 +43,7 @@ const LocationsNavigation = ({navigation}: {navigation: any}) => {
 
   const myLocationOptions = {
     title: 'My Locations',
-    headerRight: () => {
+    headerLeft: () => {
       return (
         <HamburgerButton onPress={onOpenDrawer} />
       );

--- a/src/screens/LocationsNavigation/index.tsx
+++ b/src/screens/LocationsNavigation/index.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { observer } from 'mobx-react-lite';
 import { createStackNavigator } from '@react-navigation/stack';
-import { EventArg, StackNavigationState } from '@react-navigation/native';
 
 import { LocationsStack, LocationsStackParamList } from '@/types/LocationNavTypes';
 import stackNavScreenOptions from '@/consts/stackNavOptions';
@@ -9,8 +8,7 @@ import stackNavScreenOptions from '@/consts/stackNavOptions';
 import MyLocations from './MyLocations';
 import LocationDetails from './LocationDetails';
 
-import AddButton from '@/components/Buttons/AddButton';
-import colors from '@/consts/colors';
+import HamburgerButton from '@/components/Buttons/HamburgerButton';
 import { uiStore } from '@/stores/UIStore';
 
 const { Navigator, Screen } = createStackNavigator<LocationsStackParamList>();
@@ -39,21 +37,15 @@ const LocationsNavigation = ({navigation}: {navigation: any}) => {
     prevRoute.current = currentRoute;
   }
 
-  const onPressAddLocation = () => {
-    uiStore.setAddLocationModalVisible(true);
+  const onOpenDrawer = () => {
+    navigation.openDrawer();
   };
 
   const myLocationOptions = {
     title: 'My Locations',
     headerRight: () => {
       return (
-        <AddButton
-          label="Add Location"
-          foreground={colors.white}
-          background={colors.brandColor}
-          materialIconName="add-circle"
-          onPress={onPressAddLocation}
-        />
+        <HamburgerButton onPress={onOpenDrawer} />
       );
     }
   };

--- a/src/screens/LocationsNavigation/modals/AddLocationModal.tsx
+++ b/src/screens/LocationsNavigation/modals/AddLocationModal.tsx
@@ -45,7 +45,7 @@ const AddLocationModal = () => {
 const onSubmitCurrentLocation = async (evt: any) => {
   // Capture the text value immediately to avoid event reuse issues
   const locationName = evt.nativeEvent.text;
-  
+
   try {
     const locationExplicitlyDisabled = domainStore.locationExplicitlyDisabled;
     if (locationExplicitlyDisabled) {
@@ -66,16 +66,16 @@ const onSubmitCurrentLocation = async (evt: any) => {
       );
       return; // Don't proceed if permissions are denied
     }
-    
+
     // Create the location
     await domainStore.addLocation({ name: locationName });
     uiStore.setAddLocationModalVisible(false);
   } catch (error) {
     console.error('Failed to create location:', error);
-    
+
     // Provide more specific error messages
     let errorMessage = 'Unable to get your current location. Please try again.';
-    
+
     if (error instanceof Error) {
       if (error.message.includes('Location request timed out')) {
         errorMessage = 'Location request timed out. Please check your location settings and try again.';
@@ -85,7 +85,7 @@ const onSubmitCurrentLocation = async (evt: any) => {
         errorMessage = 'Location is currently unavailable. Please try again in a moment.';
       }
     }
-    
+
     Alert.alert('Location Error', errorMessage);
   }
 }
@@ -97,9 +97,7 @@ const styles = StyleSheet.create({
     justifyContent: 'flex-start',
     alignItems: 'center',
     backgroundColor: colors.brandColor,
-    opacity: 0.9,
-    paddingVertical: 50,
-    marginTop: '60%',
+    marginTop: '50%',
   },
   modalTitle: {
     fontSize: fonts.modalTitleSize,
@@ -119,4 +117,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default observer(AddLocationModal);  
+export default observer(AddLocationModal);

--- a/src/screens/SettingsNavigation/index.tsx
+++ b/src/screens/SettingsNavigation/index.tsx
@@ -5,6 +5,8 @@ import { createStackNavigator } from '@react-navigation/stack';
 import { SettingsStack, SettingsStackParamList } from '@/types/SettingsNavTypes';
 import stackNavScreenOptions from '@/consts/stackNavOptions';
 
+import HamburgerButton from '@/components/Buttons/HamburgerButton';
+
 import MySettings from './MySettings';
 import Profile from './Profile';
 import Permissions from './Permissions';
@@ -37,9 +39,20 @@ const SettingsNavigation = ({navigation}: {navigation: any}) => {
     prevRoute.current = currentRoute;
   }
 
+  const onOpenDrawer = () => {
+    navigation.openDrawer();
+  };
+
   return (
     <Navigator initialRouteName="MySettings" screenOptions={stackNavScreenOptions} screenListeners={{ state: onScreenChange }}>
-      <Screen name="MySettings" component={MySettings} options={{ title: 'My Settings' }} />
+      <Screen
+        name="MySettings"
+        component={MySettings}
+        options={{
+          title: 'My Settings',
+          headerRight: () => <HamburgerButton onPress={onOpenDrawer} />
+        }}
+      />
       <Screen name="Profile" component={Profile} options={{ title: 'Profile' }} />
       <Screen name="Permissions" component={Permissions} options={{ title: 'Permissions' }} />
       <Screen name="About" component={About} options={{ title: 'About' }} />

--- a/src/screens/SettingsNavigation/index.tsx
+++ b/src/screens/SettingsNavigation/index.tsx
@@ -50,7 +50,7 @@ const SettingsNavigation = ({navigation}: {navigation: any}) => {
         component={MySettings}
         options={{
           title: 'My Settings',
-          headerRight: () => <HamburgerButton onPress={onOpenDrawer} />
+          headerLeft: () => <HamburgerButton onPress={onOpenDrawer} />
         }}
       />
       <Screen name="Profile" component={Profile} options={{ title: 'Profile' }} />

--- a/src/stores/UIStore.ts
+++ b/src/stores/UIStore.ts
@@ -43,6 +43,7 @@ export const UIStoreModel = t.model('UIStoreModel', {
     showCategoryLabels: t.optional(t.boolean, true),
     allFoldersOpen: t.optional(t.boolean, false),
     reorderCategoriesModalVisible: t.optional(t.boolean, false),
+    reorderListsModalVisible: t.optional(t.boolean, false),
 })
 .actions(self => ({
     initialize: () => {
@@ -166,6 +167,9 @@ export const UIStoreModel = t.model('UIStoreModel', {
     },
     setReorderCategoriesModalVisible(reorderCategoriesModalVisible: boolean) {
         self.reorderCategoriesModalVisible = reorderCategoriesModalVisible;
+    },
+    setReorderListsModalVisible(reorderListsModalVisible: boolean) {
+        self.reorderListsModalVisible = reorderListsModalVisible;
     }
 }));
 


### PR DESCRIPTION
This is a pretty substantial refactor of the UX.

- Bottom tab navigation has been replaced with common actions bar
- Drawer navigation now in place on left with hamburger menu to switch between major sections of the app, which happens infrquently
- Item input is streamlined so that the user has several fewer clicks to make
- My Lists screen redesign to have separate reorder lists modal
- Now can rename lists via context menu